### PR TITLE
Support v0.16.0 - Rename parameter query-frontend.log_queries_longer_than to query-frontend.log-queries-longer-than

### DIFF
--- a/manifests/query_frontend.pp
+++ b/manifests/query_frontend.pp
@@ -99,7 +99,7 @@ class thanos::query_frontend (
       'http-grace-period'                        => $http_grace_period,
       'query-frontend.downstream-url'            => $query_frontend_downstream_url,
       'query-frontend.compress-responses'        => $query_frontend_compress_responses,
-      'query-frontend.log_queries_longer_than'   => $query_frontend_log_queries_longer_than,
+      'query-frontend.log-queries-longer-than'   => $query_frontend_log_queries_longer_than,
       'log.request.decision'                     => $log_request_decision,
     },
     extra_params => $extra_params,

--- a/spec/classes/query_frontend_spec.rb
+++ b/spec/classes/query_frontend_spec.rb
@@ -38,7 +38,7 @@ describe 'thanos::query_frontend' do
             'http-grace-period'                        => '2m',
             'query-frontend.downstream-url'            => 'http://localhost:9090',
             'query-frontend.compress-responses'        => false,
-            'query-frontend.log_queries_longer_than'   => 0,
+            'query-frontend.log_queries-longer-than'   => 0,
             'log.request.decision'                     => nil,
           },
         )

--- a/spec/classes/query_frontend_spec.rb
+++ b/spec/classes/query_frontend_spec.rb
@@ -38,7 +38,7 @@ describe 'thanos::query_frontend' do
             'http-grace-period'                        => '2m',
             'query-frontend.downstream-url'            => 'http://localhost:9090',
             'query-frontend.compress-responses'        => false,
-            'query-frontend.log_queries-longer-than'   => 0,
+            'query-frontend.log-queries-longer-than'   => 0,
             'log.request.decision'                     => nil,
           },
         )


### PR DESCRIPTION
Change param `log_queries_longer_than ` to `log-queries-longer-than` according https://github.com/thanos-io/thanos/pull/3114 in v0.16.0