### PR TITLE
make config dir traversable for group

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -131,6 +131,7 @@ class thanos::install (
     ensure  => 'directory',
     owner   => 'root',
     group   => $group,
+    mode    => '0750',
     purge   => $purge_config_dir,
     recurse => $purge_config_dir,
   }


### PR DESCRIPTION
default umask in Ubuntu makes it untraversable. Make sure to allow group to read it's config.