### PR TITLE
fix: change query_frontend_log_queries_longer_than to String

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1549,7 +1549,7 @@ Default value: ``false``
 
 ##### <a name="query_frontend_log_queries_longer_than"></a>`query_frontend_log_queries_longer_than`
 
-Data type: `Integer`
+Data type: `String`
 
 Log queries that are slower than the specified duration. Set to 0 to disable. Set to < 0 to enable on all queries.
 

--- a/manifests/query_frontend.pp
+++ b/manifests/query_frontend.pp
@@ -73,7 +73,7 @@ class thanos::query_frontend (
   String                         $http_grace_period                        = '2m',
   Stdlib::HTTPUrl                $query_frontend_downstream_url            = 'http://localhost:9090',
   Boolean                        $query_frontend_compress_responses        = false,
-  Integer                        $query_frontend_log_queries_longer_than   = 0,
+  String                         $query_frontend_log_queries_longer_than   = "0",
   Optional[String]               $log_request_decision                     = undef,
   # Extra parametes
   Hash                           $extra_params                             = {},

--- a/spec/classes/query_frontend_spec.rb
+++ b/spec/classes/query_frontend_spec.rb
@@ -38,7 +38,7 @@ describe 'thanos::query_frontend' do
             'http-grace-period'                        => '2m',
             'query-frontend.downstream-url'            => 'http://localhost:9090',
             'query-frontend.compress-responses'        => false,
-            'query-frontend.log-queries-longer-than'   => 0,
+            'query-frontend.log-queries-longer-than'   => "0",
             'log.request.decision'                     => nil,
           },
         )


### PR DESCRIPTION
query_frontend_log_queries_longer_than in Thanos query frontend should be a String as it should include the time units.