### PR TITLE
Support thanos user as owner of config_dir

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -127,7 +127,7 @@ class thanos::install (
 
   file { $config_dir:
     ensure  => 'directory',
-    owner   => 'root',
+    owner   => $user,
     group   => $group,
     mode    => '0750',
     purge   => $purge_config_dir,


### PR DESCRIPTION
From issue: https://github.com/syberalexis/puppet-thanos/issues/53